### PR TITLE
Improve functionality to download SPICE kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dev
 # Compiled extension modules
 *.so
 _version.py
+build

--- a/src/pride/delays/models.py
+++ b/src/pride/delays/models.py
@@ -48,6 +48,10 @@ class Geometric(Delay):
         if not metak_path.exists():
             log.info(f"Downloading metakernel for {target['names'][-1]}")
             metak_found: bool = False
+            log.debug(
+                "Downloading: "
+                f"{kernel_source}/mk/{target['meta_kernel'].upper()}"
+            )
             response = requests.get(
                 f"{kernel_source}/mk/{target['meta_kernel'].upper()}"
             )

--- a/src/pride/io/spice.py
+++ b/src/pride/io/spice.py
@@ -1,6 +1,7 @@
 from .resources import load_catalog
 from typing import Any
 from ..logger import log
+from pathlib import Path
 
 ESA_SPICE = "https://spiftp.esac.esa.int/data/SPICE"
 NASA_SPICE = "https://naif.jpl.nasa.gov/pub/naif"


### PR DESCRIPTION
# Description

The current solution for downloading SPICE kernels only works if the name of the metakernel file is all in upper case. Additionally, the functionality is implemented within the source code of the geometric delay, instead of being part of the `io` module, where it naturally belongs.

The purpose of this PR is to move the code for handling kernels to `io`, and allow for a correct handling of a larger variety of metakernel naming conventions.